### PR TITLE
fix: correct usage of bip39 library

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,8 +35,7 @@ const generateKeys = async (seed, algorithm, options) => {
 
 const generateKeyPair = async (algorithm, options) => {
     const mnemonic = bip39.generateMnemonic();
-    const seedBuffer = await bip39.mnemonicToSeed(mnemonic);
-    const seed = new Uint8Array(seedBuffer.buffer);
+    const seed = await bip39.mnemonicToSeed(mnemonic);
 
     const { keyAlgorithm, composedKeyPair } = await generateKeys(seed, algorithm, options);
 
@@ -49,8 +48,7 @@ const generateKeyPair = async (algorithm, options) => {
 };
 
 const getKeyPairFromMnemonic = async (mnemonic, algorithm, options) => {
-    const seedBuffer = await bip39.mnemonicToSeed(mnemonic);
-    const seed = new Uint8Array(seedBuffer.buffer);
+    const seed = await bip39.mnemonicToSeed(mnemonic);
 
     return getKeyPairFromSeed(seed, algorithm, options);
 };


### PR DESCRIPTION
The previous implementation used the bip39 library incorrectly. Instead of the current approach, we should directly use the buffer returned by bip39.mnemonicToSeed.

Closes #28